### PR TITLE
build: fix EOL Debian Buster apt (archive.debian.org)

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,8 +1,22 @@
+# Build of arbimon-soundscapes. The base
+# image python:3.8-buster targets Debian Buster, which is EOL — its repos
+# moved to archive.debian.org and the live deb.debian.org mirrors now 404.
+# We redirect sources.list to the archive (and disable the Valid-Until
+# check, since archive snapshots have stale Release dates) so apt works.
+# Toolchain otherwise unchanged (python 3.8, buster R, seewave 1.7.6) to
+# preserve numerical-result parity with the legacy jobqueue worker.
+#
 FROM python:3.8-buster AS arbimon-soundscapes
+
+# Redirect Buster apt to the Debian archive (EOL distro) before installing.
+RUN set -eux; \
+    sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g; s|http://deb.debian.org/debian-security|http://archive.debian.org/debian-security|g; s|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list; \
+    printf 'Acquire::Check-Valid-Until "false";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99archive
 
 # Install R, sox and libsndfile/libfftw (required by seewave)
 RUN apt-get update && \
-    apt-get install -y opus-tools sox r-base r-cran-devtools libsndfile-dev libfftw3-3 libfftw3-dev pkg-config
+    apt-get install -y --no-install-recommends opus-tools sox r-base r-cran-devtools libsndfile-dev libfftw3-3 libfftw3-dev pkg-config && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install seewave (R package)
 ARG SEEWAVE_VERSION=1.7.6


### PR DESCRIPTION
## Problem

`docker build` of `build/Dockerfile` fails at `apt-get update`: the base image `python:3.8-buster` targets Debian Buster, which is EOL. Its apt repos moved to `archive.debian.org` and the live `deb.debian.org` mirrors return 404 (`The repository '... buster Release' does not have a Release file`).

## Fix

Redirect `sources.list` to `archive.debian.org` and disable the `Valid-Until` check (archive snapshots carry stale Release dates) before installing. Toolchain otherwise unchanged (python 3.8, buster R, seewave 1.7.6) to preserve numerical parity. Also `--no-install-recommends` + apt-list cleanup to slim the image.

## Context

Surfaced while building this worker for the rfcx-local (AWS-free) deployment, where soundscape jobs run as in-cluster k8s Jobs. The image now builds clean on arm64 and runs real jobs end-to-end.