### PR TITLE
rfcx-local: CD build+push to local cluster (Dockerfile EOL fix + cd.yaml)

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -57,6 +57,16 @@ jobs:
     secrets:
       kube-config: ${{ secrets.KUBE_CONFIG_SUPER }}
 
+  deploy-rfcx-local:
+    name: 'Deploy (rfcx-local)'
+    needs: [prepare, configure]
+    if: ${{ needs.configure.outputs.namespace == 'production' }}
+    uses: rfcx/cicd/.github/workflows/rfcx-local-worker-cd.yaml@master
+    with:
+      dockerfile: build/Dockerfile
+      image: arbimon-soundscapes
+      repo: arbimon-soundscapes
+
   notify:
     name: 'Notify'
     if: ${{ always() }}

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,10 @@
 FROM python:3.8-buster AS arbimon-soundscapes
 
+# Buster is EOL; redirect apt to the Debian archive so apt-get update works.
+RUN set -eux; \
+    sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g; s|http://deb.debian.org/debian-security|http://archive.debian.org/debian-security|g; s|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list; \
+    printf 'Acquire::Check-Valid-Until "false";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99archive
+
 # Install R, sox and libsndfile/libfftw (required by seewave)
 RUN apt-get update && \
     apt-get install -y opus-tools sox r-base r-cran-devtools libsndfile-dev libfftw3-3 libfftw3-dev pkg-config


### PR DESCRIPTION
On master push, build arbimon-soundscapes on the in-cluster runner and push rfcx-local-prod-<sha>+latest to the local registry (dispatcher-spawned worker). Includes the EOL-Buster apt fix so the image builds. AWS ECR path unaffected.