### PR TITLE
Worker: error on total download failure + legacy recs via S3_ENDPOINT chain + seewave build fix (gfortran/signal)

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,15 +5,20 @@ RUN set -eux; \
     sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g; s|http://deb.debian.org/debian-security|http://archive.debian.org/debian-security|g; s|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list; \
     printf 'Acquire::Check-Valid-Until "false";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99archive
 
-# Install R, sox and libsndfile/libfftw (required by seewave)
+# Install R, sox and libsndfile/libfftw (required by seewave).
+# gfortran is REQUIRED: seewave -> tuneR -> signal, and the `signal` R package
+# has Fortran sources (dpchim.f). Without gfortran its compile dies with
+# `make: Error 127`, which silently leaves tuneR+seewave uninstalled.
 RUN apt-get update && \
-    apt-get install -y opus-tools sox r-base r-cran-devtools libsndfile-dev libfftw3-3 libfftw3-dev pkg-config
+    apt-get install -y opus-tools sox r-base r-cran-devtools libsndfile-dev libfftw3-3 libfftw3-dev pkg-config gfortran
 
 # Install seewave (R package)
 ARG SEEWAVE_VERSION=1.7.6
-# seewave needs the R packages fftw + tuneR; with repos=NULL (Archive
-# tarball) R will NOT auto-resolve them, so install deps from CRAN first.
-RUN Rscript -e "install.packages(c('fftw','tuneR'), repos='https://cloud.r-project.org')" && \
+# seewave needs the R packages fftw + tuneR (and tuneR needs signal); with
+# repos=NULL (Archive tarball) R will NOT auto-resolve them, so install the
+# deps from CRAN first. signal is listed explicitly so a missing toolchain
+# surfaces here rather than as a confusing transitive tuneR failure.
+RUN Rscript -e "install.packages(c('signal','fftw','tuneR'), repos='https://cloud.r-project.org')" && \
     if [ "$SEEWAVE_VERSION" = "latest" ]; then \
         Rscript -e 'install.packages("seewave", repos="https://cloud.r-project.org")'; \
     else \

--- a/soundscapes/old/a2audio/rec.py
+++ b/soundscapes/old/a2audio/rec.py
@@ -147,6 +147,25 @@ class Rec:
         return True
 
     def getAudioFromLegacyUri(self, retries=6):
+        # rfcx-local 2026-06-09: route legacy (project_*) recordings through
+        # the S3_ENDPOINT chain via boto3 (same as getAudioFromUri) instead of
+        # hardcoding https://s3.amazonaws.com + urllib, which bypassed the
+        # in-cluster storage chain and hit AWS directly. When S3_ENDPOINT is
+        # set we use boto3; otherwise we fall back to the original AWS-direct
+        # urllib path (preserves upstream/AWS behaviour when unconfigured).
+        if config.get('s3_endpoint'):
+            s3 = boto3.resource('s3',
+                                aws_access_key_id=config['s3_access_key_id'],
+                                aws_secret_access_key=config['s3_secret_access_key'],
+                                endpoint_url=config['s3_endpoint'])
+            b = s3.Bucket(self.bucket)
+            try:
+                b.download_file(self.uri, self.localfilename)
+            except Exception:
+                print(("missing file (legacy via chain). {} {}".format(self.bucket, self.uri)))
+                return False
+            return True
+
         start_time = time.time()
         f = None
         url = 'https://s3.amazonaws.com/' + self.bucket + '/' + self.uri

--- a/soundscapes/old/playlist_to_soundscape.py
+++ b/soundscapes/old/playlist_to_soundscape.py
@@ -353,6 +353,38 @@ def playlist_to_soundscape(job_id, output_folder = tempfile.gettempdir()):
             aciFile = working_folder+'aci'
             aciIndex.write_index_aggregation_json(aciFile+'.json')
 
+            # rfcx-local 2026-06-09: guard against silent blank-soundscape
+            # 'completion'. If NO recording yielded usable peak data
+            # (max_count==0) the soundscape image is degenerate/blank — this
+            # is what happened when every recording 404'd from the wrong
+            # download bucket (jobs still marked 'completed'). Treat it as an
+            # error so the failure is visible and re-runnable, instead of
+            # persisting a blank image + a max_value=0 row.
+            if scp.stats.get('max_count', 0) <= 0:
+                print('main: failed: no usable recording data (max_count=0); '
+                      'all recordings missing/unreadable — not writing a blank '
+                      'soundscape')
+                # NOTE: the arbimon2 `jobs_BEFORE_UPDATE` trigger force-sets
+                # state='completed' whenever progress >= progress_steps. The
+                # per-rec progress bumps can push progress past progress_steps,
+                # so reset progress below progress_steps in the SAME UPDATE or
+                # the trigger will override our state='error' back to
+                # 'completed'. (completed=-1 is the authoritative error flag
+                # regardless, but keep state consistent for the frontend.)
+                with contextlib.closing(db.cursor()) as cursor:
+                    cursor.execute('update `jobs` set `state`="error", '
+                        '`completed` = -1, `progress` = 0, '
+                        '`remarks` = \'Error: no usable '
+                        'recording data (all recordings missing or unreadable).\' '
+                        'where `job_id` = '+str(job_id))
+                    db.commit()
+                shutil.rmtree(working_folder)
+                db.close()
+                # match the other failure paths (sys.exit(-1)) so the worker
+                # terminates here and does NOT fall through to the trailing
+                # 'state=completed' update at the end of this try block.
+                sys.exit(-1)
+
             if aggregation['range'] == 'auto':
                 statsMin = scp.stats['min_idx']
                 statsMax = scp.stats['max_idx']


### PR DESCRIPTION
## Summary

Three fixes found while operating the in-cluster (AWS-free) soundscape worker on rfcx-local. In that environment, soundscape jobs were `completing` but rendering **blank** (`soundscapes.max_value=0`, ~860-byte degenerate `image.png`). Root cause of the blank images was an env/bucket misconfig in our dispatcher (fixed on our side), but diagnosing it surfaced three real worker-side issues worth upstreaming.

### 1. Error instead of silently "completing" a blank soundscape
`soundscapes/old/playlist_to_soundscape.py`: when **no** recording yields usable peak data (`scp.stats['max_count'] <= 0`) — e.g. every recording failed to download — the worker previously still wrote a blank image and marked the job `completed`, hiding the failure. Now it sets `state='error'`, `completed=-1`, writes **no** soundscape row, and `sys.exit(-1)` like the other failure paths.

Note: it also resets `progress=0` in the same UPDATE. Our DB has a `jobs_BEFORE_UPDATE` trigger that force-sets `state='completed'` when `progress >= progress_steps`; without the reset the trigger overrides the error state. `completed=-1` is the authoritative error flag regardless, so this is harmless where that trigger doesn't exist.

### 2. Route legacy (`project_*`) recordings through `S3_ENDPOINT`
`soundscapes/old/a2audio/rec.py` `getAudioFromLegacyUri()` always fetched legacy recordings from `https://s3.amazonaws.com/<bucket>/<uri>` via `urllib`, bypassing any custom storage endpoint and hitting AWS directly. It now uses `boto3` with `endpoint_url` (like `getAudioFromUri()`) **when `S3_ENDPOINT` is set**, and falls back to the original `urllib`/AWS path when it isn't — so there's **no behaviour change for stock AWS deployments**.

### 3. Fix the seewave build (`build/Dockerfile`)
`seewave -> tuneR -> signal`, and the `signal` R package has Fortran sources (`dpchim.f`). Without **gfortran** its compile fails with `make: Error 127`, which silently leaves `tuneR` + `seewave` uninstalled — and `fpeaks.R` then dies at runtime with *"there is no package called 'seewave'"*. This adds `gfortran` to apt and installs `signal` explicitly alongside `fftw`/`tuneR`. The existing `requireNamespace('seewave')` assert already fails the build if the install fails.

## Testing
- Built the image on arm64 with the new Dockerfile — seewave imports (`SEEWAVE_IMPORT_OK`); the build now **fails loudly** if the R stack is broken instead of shipping a seewave-less image.
- Fix #1 verified end-to-end: a job whose recordings all 404 → `state=error`, `completed=-1`, zero soundscape rows.
- Fix #2 verified end-to-end with a playlist of real legacy `project_*` recordings routed through a non-AWS `S3_ENDPOINT` → soundscape produced with real content; worker log shows the `project_*` downloads succeeding via the endpoint (no `s3.amazonaws.com`).
- Normal (non-degenerate) jobs unchanged: real `max_value`, real PNG.

## Notes
Targets `master` (the branch our local CD builds from). No API/schema changes. `develop` is behind `master` on the seewave Dockerfile; happy to also retarget/backport if preferred.