### PR TITLE
mysql2pg W5: dialect-aware soundscapes worker + explicit job completion (#40)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,9 @@ soundfile==0.12.1
 
 # For batch legacy
 mysql-connector-python==8.1.0
+# mysql2pg Phase 5.5 (W5): postgres driver for the dialect-aware db.py.
+# Inactive unless ARBIMON_DB_DIALECT=postgres (set at the coordinated flip).
+psycopg2-binary==2.9.9
 boto3==1.28.71
 
 # Dev

--- a/soundscapes/old/db.py
+++ b/soundscapes/old/db.py
@@ -1,23 +1,130 @@
 import base64
 import hashlib
 import os
-import mysql.connector
 from typing import Union
+
+# mysql2pg Phase 5.5 (W5, 2026-07-16): dialect-aware DB layer.
+# ARBIMON_DB_DIALECT=mysql (DEFAULT - byte-for-byte today's behavior) or
+# postgres. The PG path activates ONLY via env at the coordinated jobs-plane
+# flip; nothing changes for existing deploys. Env names stay DB_* for both
+# dialects (the flip changes env VALUES, not names; ARBIMON_DB_PORT overrides
+# DB_PORT when set). Mirrors the W1/W4 pattern.
+#
+# SQL portability changes carried across this worker (validated equivalent
+# both ways):
+#   - backticks stripped (the schema names are all lowercase; PG identifiers
+#     unquoted, MySQL accepts unquoted lowercase identically)
+#   - double-quoted STRING literals -> single quotes ("processing" is an
+#     IDENTIFIER to PG and would hard-error)
+#   - MySQL year()/DATE_FORMAT()/IF(LEFT()) -> dialect-appropriate expressions
+#     (helpers below; identical results on both engines)
+#   - cursor.lastrowid -> INSERT ... RETURNING on PG (helper below)
+
+DIALECT = os.getenv('ARBIMON_DB_DIALECT', 'mysql').lower()
+IS_PG = DIALECT in ('postgres', 'postgresql', 'pg')
+
+if IS_PG:
+    import psycopg2
+    import psycopg2.errors  # noqa: F401
+else:
+    import mysql.connector
 
 config = {
     'db_host': os.getenv('DB_HOST'),
+    'db_port': int(os.getenv('ARBIMON_DB_PORT') or os.getenv('DB_PORT', '3306')),
     'db_user': os.getenv('DB_USER'),
     'db_password': os.getenv('DB_PASSWORD'),
     'db_name': os.getenv('DB_NAME'),
 }
 
+
 def connect():
+    if IS_PG:
+        return psycopg2.connect(
+            host=config['db_host'],
+            port=config['db_port'],
+            user=config['db_user'],
+            password=config['db_password'],
+            dbname=config['db_name'],
+            connect_timeout=10,
+        )
     return mysql.connector.connect(
         host=config['db_host'],
         user=config['db_user'],
-        password=config['db_password'], 
+        password=config['db_password'],
         database=config['db_name']
     )
+
+
+# --- tiny dialect helpers -------------------------------------------------
+
+def year_expr(column):
+    """MySQL year(col) -> PG EXTRACT(YEAR FROM col). Numeric both ways."""
+    return 'EXTRACT(YEAR FROM {})'.format(column) if IS_PG else 'year({})'.format(column)
+
+
+# MySQL DATE_FORMAT() spec -> PG to_char() pattern, for the aggregation date
+# tokens used by soundscape.py (aggregations dict). %w is special: MySQL %w is
+# 0=Sunday..6=Saturday; PG to_char 'D' is 1=Sunday..7=Saturday (off by one), so
+# %w maps to EXTRACT(DOW ...) which is 0=Sunday..6=Saturday (matches MySQL).
+_DATEFMT_MYSQL_TO_PG = {
+    '%H': "to_char({col}, 'HH24')",   # hour 00-23
+    '%d': "to_char({col}, 'DD')",     # day of month 01-31
+    '%j': "to_char({col}, 'DDD')",    # day of year 001-366
+    '%m': "to_char({col}, 'MM')",     # month 01-12
+    '%Y': "to_char({col}, 'YYYY')",   # year
+    '%w': "CAST(EXTRACT(DOW FROM {col}) AS INTEGER)",  # 0=Sun..6=Sat
+}
+
+
+def date_format_expr(column, mysql_fmt):
+    """Return a dialect-appropriate expression equivalent to
+    MySQL DATE_FORMAT(column, mysql_fmt) for the soundscape aggregation tokens.
+
+    On MySQL this reproduces the exact original expression (double-quoted fmt,
+    byte-identical). On PG it maps the token to the equivalent to_char/EXTRACT.
+    """
+    if not IS_PG:
+        return 'DATE_FORMAT({}, "{}")'.format(column, mysql_fmt)
+    tpl = _DATEFMT_MYSQL_TO_PG.get(mysql_fmt)
+    if tpl is None:
+        raise ValueError('unsupported DATE_FORMAT token for PG port: {!r}'.format(mysql_fmt))
+    return tpl.format(col=column)
+
+
+def datetime_str_expr(column):
+    """MySQL DATE_FORMAT(col, '%Y-%m-%d %H:%i:%s') -> PG to_char(col,
+    'YYYY-MM-DD HH24:MI:SS'). Both yield a string later parsed with
+    strptime('%Y-%m-%d %H:%M:%S'); identical text on both engines."""
+    if IS_PG:
+        return "to_char({}, 'YYYY-MM-DD HH24:MI:SS')".format(column)
+    return "DATE_FORMAT({}, '%Y-%m-%d %H:%i:%s')".format(column)
+
+# IF(LEFT(uri,8)='project_',1,0) equivalent, identical result both engines.
+# MySQL IF() does not exist in PG; CASE is identical on both.
+LEGACY_EXPR = "CASE WHEN LEFT(r.uri, 8) = 'project_' THEN 1 ELSE 0 END"
+
+
+def cursor_column_names(cursor):
+    """mysql.connector exposes cursor.column_names; psycopg2 uses
+    cursor.description. Return the column-name tuple dialect-neutrally."""
+    if IS_PG:
+        return tuple(col.name for col in cursor.description)
+    return cursor.column_names
+
+
+def insert_returning_id(cursor, sql, params, id_column):
+    """INSERT and return the generated id, dialect-appropriately.
+
+    MySQL: execute + cursor.lastrowid. PG: append RETURNING <id_column> and
+    fetch. The caller's SQL must NOT already carry RETURNING.
+    """
+    if IS_PG:
+        cursor.execute(sql + ' RETURNING ' + id_column, params)
+        return cursor.fetchone()[0]
+    cursor.execute(sql, params)
+    return cursor.lastrowid
+
 
 def get_automated_user(conn):
     cursor = conn.cursor()
@@ -29,10 +136,13 @@ def get_automated_user(conn):
         cursor.close()
         (user_id,) = result
         return user_id
-    
-    cursor.execute('''insert into users (login, password, firstname, lastname, email) values (%s, '',  'Automated', 'Job', 'automated-user@arbimon.org')''', (automated_user,))
+
+    user_id = insert_returning_id(
+        cursor,
+        '''insert into users (login, password, firstname, lastname, email) values (%s, '',  'Automated', 'Job', 'automated-user@arbimon.org')''',
+        (automated_user,),
+        'user_id')
     conn.commit()
-    user_id = cursor.lastrowid
 
     cursor.close()
     return user_id
@@ -94,7 +204,7 @@ def create_playlist(conn, project_id, site_id, site_name, year):
     playlist_name = f'{site_name} ({site_id}) {year}'
     cursor = conn.cursor()
 
-    cursor.execute('select count(*) from recordings where site_id = %s and year(datetime) = %s', (site_id, year))
+    cursor.execute('select count(*) from recordings where site_id = %s and ' + year_expr('datetime') + ' = %s', (site_id, year))
     (total_recordings,) = cursor.fetchone()
 
     # No recordings
@@ -115,13 +225,16 @@ def create_playlist(conn, project_id, site_id, site_name, year):
         playlist_name += f' {total_recordings}'
     
     # Create playlists row
-    cursor.execute('insert into playlists (project_id, name, playlist_type_id, total_recordings) values (%s, %s, 1, %s)', (project_id, playlist_name, total_recordings))
+    playlist_id = insert_returning_id(
+        cursor,
+        'insert into playlists (project_id, name, playlist_type_id, total_recordings) values (%s, %s, 1, %s)',
+        (project_id, playlist_name, total_recordings),
+        'playlist_id')
     conn.commit()
-    playlist_id = cursor.lastrowid
 
     # Create playlist_recordings rows
     cursor.execute('''insert into playlist_recordings (playlist_id, recording_id)
-        select %s, recording_id from recordings where site_id = %s and year(datetime) = %s''', (playlist_id, site_id, year))
+        select %s, recording_id from recordings where site_id = %s and ''' + year_expr('datetime') + ' = %s', (playlist_id, site_id, year))
     conn.commit()
 
     if cursor.rowcount != total_recordings:
@@ -152,12 +265,13 @@ def create_job(conn, playlist_id, user_id, aggregation = 'time_of_day', bin_size
     job_name = playlist_name if soundscape_name is None else soundscape_name
     # job_name_suffix = soundscape_hash(playlist_id, aggregation_type_id, bin_size, threshold, normalize) # TODO make job name unique
 
-    cursor.execute(
+    job_id = insert_returning_id(
+        cursor,
         '''insert into jobs (job_type_id, date_created, last_update, project_id, user_id, state, progress_steps, remarks, uri, hidden) 
         values (4, now(), now(), %s, %s, 'initializing', %s, '', '', 0)''',
-        (project_id, user_id, total_recordings))
+        (project_id, user_id, total_recordings),
+        'job_id')
     conn.commit()
-    job_id = cursor.lastrowid
 
     cursor.execute(
         '''insert into job_params_soundscape (job_id, playlist_id, name, max_hertz, soundscape_aggregation_type_id, bin_size, threshold, normalize) 

--- a/soundscapes/old/db.py
+++ b/soundscapes/old/db.py
@@ -149,20 +149,27 @@ def get_automated_user(conn):
 
 def find_project(conn, url_or_id):
     cursor = conn.cursor()
-    
+
     conditions = [
         'url = %s',
         'external_id = %s',
         'project_id = %s'
     ]
     for condition in conditions:
+        # mysql2pg: project_id is an integer column. MySQL silently coerces a
+        # non-numeric string to 0 (never matches); PG hard-errors on
+        # integer = text. Skip the numeric condition for non-numeric input on
+        # BOTH dialects (behavior-identical: the MySQL coercion also never
+        # matched a real project).
+        if condition.startswith('project_id') and not str(url_or_id).isdigit():
+            continue
         cursor.execute(f'select project_id from projects where {condition}', (url_or_id, ))
         result = cursor.fetchone()
         if result is not None:
             cursor.close()
             (project_id,) = result
             return project_id
-    
+
     cursor.close()
     return None
 
@@ -204,7 +211,12 @@ def create_playlist(conn, project_id, site_id, site_name, year):
     playlist_name = f'{site_name} ({site_id}) {year}'
     cursor = conn.cursor()
 
-    cursor.execute('select count(*) from recordings where site_id = %s and ' + year_expr('datetime') + ' = %s', (site_id, year))
+    # mysql2pg: EXTRACT(YEAR ...) is numeric on PG; a str-typed year param
+    # binds as text -> numeric = text hard-errors (MySQL coerces silently).
+    # Coerce to int on both dialects (identical result; None stays None and
+    # never matches, same as today).
+    year_param = int(year) if year is not None else None
+    cursor.execute('select count(*) from recordings where site_id = %s and ' + year_expr('datetime') + ' = %s', (site_id, year_param))
     (total_recordings,) = cursor.fetchone()
 
     # No recordings
@@ -234,7 +246,7 @@ def create_playlist(conn, project_id, site_id, site_name, year):
 
     # Create playlist_recordings rows
     cursor.execute('''insert into playlist_recordings (playlist_id, recording_id)
-        select %s, recording_id from recordings where site_id = %s and ''' + year_expr('datetime') + ' = %s', (playlist_id, site_id, year))
+        select %s, recording_id from recordings where site_id = %s and ''' + year_expr('datetime') + ' = %s', (playlist_id, site_id, year_param))
     conn.commit()
 
     if cursor.rowcount != total_recordings:

--- a/soundscapes/old/playlist_to_soundscape.py
+++ b/soundscapes/old/playlist_to_soundscape.py
@@ -16,7 +16,17 @@ from .a2audio.rec import Rec
 from .a2pyutils import palette
 from .indices import indices
 from .soundscape import soundscape
-from .db import connect
+from . import db as dbmod
+from .db import (
+    connect,
+    year_expr,  # noqa: F401
+    date_format_expr,
+    datetime_str_expr,
+    LEGACY_EXPR,
+    cursor_column_names,
+    insert_returning_id,
+    IS_PG,
+)
 
 config = {
     's3_access_key_id': os.getenv('AWS_ACCESS_KEY_ID'),
@@ -31,15 +41,18 @@ currDir = os.path.dirname(os.path.abspath(__file__))
 # aggregation is 'time_of_day' (see soundscape.py for options)
 def get_norm_vector(db, aggregation, playlist_id):
     norm_vector = {}
+    # mysql2pg: DATE_FORMAT(R.datetime, '<token>') -> dialect-appropriate
+    # expression (to_char/EXTRACT on PG). aggregation['date'] holds MySQL
+    # format tokens (e.g. '%H'); date_format_expr maps each per dialect.
     date_parts = [
-        'DATE_FORMAT(R.datetime, "{}")'.format(dp)
+        date_format_expr('R.datetime', dp)
         for dp in aggregation['date']
     ]
     with contextlib.closing(db.cursor()) as cursor:
         cursor.execute('''
             SELECT {} , COUNT(*) as count
-            FROM `playlist_recordings` PR
-            JOIN `recordings` R ON R.recording_id = PR.recording_id
+            FROM playlist_recordings PR
+            JOIN recordings R ON R.recording_id = PR.recording_id
             WHERE PR.playlist_id = {}
             GROUP BY {}
         '''.format(
@@ -50,7 +63,7 @@ def get_norm_vector(db, aggregation, playlist_id):
             int(playlist_id),
             ', '.join(date_parts)
         ))
-        for row in [dict(zip(cursor.column_names, r)) for r in cursor.fetchall()]:
+        for row in [dict(zip(cursor_column_names(cursor), r)) for r in cursor.fetchall()]:
             idx = sum([
                 int(row['dp_{}'.format(i)]) * p
                 for i, p in enumerate(aggregation['projection'])
@@ -121,11 +134,14 @@ def playlist_to_soundscape(job_id, output_folder = tempfile.gettempdir()):
 
     try:
         #------------------------------- PREPARE --------------------------------------------------------------------------------------------------------------------
-        q = ("SELECT r.`recording_id`,`uri`, DATE_FORMAT( `datetime` , \
-            '%Y-%m-%d %H:%i:%s') as date, IF(LEFT(r.uri, 8) = 'project_', 1, 0) legacy \
-            FROM `playlist_recordings` pr \
-            JOIN `recordings` r ON pr.`recording_id` = r.`recording_id` \
-            WHERE `playlist_id` = " + str(playlist_id))
+        # mysql2pg: DATE_FORMAT(datetime,'%Y-%m-%d %H:%i:%s') ->
+        # datetime_str_expr (to_char on PG, byte-identical text on MySQL);
+        # IF(LEFT(...)) -> LEGACY_EXPR CASE (identical both engines);
+        # backticks stripped (all-lowercase identifiers, portable both ways).
+        q = ("SELECT r.recording_id, uri, " + datetime_str_expr('datetime') + " as date, " + LEGACY_EXPR + " legacy \
+            FROM playlist_recordings pr \
+            JOIN recordings r ON pr.recording_id = r.recording_id \
+            WHERE playlist_id = " + str(playlist_id))
 
         print('main: log: retrieving playlist recordings list')
         totalRecs = 0
@@ -145,18 +161,18 @@ def playlist_to_soundscape(job_id, output_folder = tempfile.gettempdir()):
             print('main: log: playlist recordings list retrieved', totalRecs)
         try:
             with contextlib.closing(db.cursor()) as cursor:
-                cursor.execute('update `jobs` set state="processing", `progress` = 1,\
-                    `progress_steps` = '+str(int(totalRecs)+5)+' \
-                    where `job_id` = '+str(job_id))
+                cursor.execute("update jobs set state='processing', progress = 1,\
+                    progress_steps = "+str(int(totalRecs)+5)+", last_update = now() \
+                    where job_id = "+str(job_id))
                 db.commit()
         except Exception as e:
             print(str(e))
         if len(recsToProcess) < 1:
             print('main: failed: invalid playlist or no recordings on playlist')
             with contextlib.closing(db.cursor()) as cursor:
-                cursor.execute('update `jobs` set `state`="error", \
-                    `completed` = -1,`remarks` = \'Error: Invalid playlist \
-                    (Maybe empty).\' where `job_id` = '+str(job_id))
+                cursor.execute("update jobs set state='error', \
+                    completed = -1, remarks = 'Error: Invalid playlist \
+                    (Maybe empty).', last_update = now() where job_id = "+str(job_id))
                 db.commit()
             sys.exit(-1)
 
@@ -186,7 +202,7 @@ def playlist_to_soundscape(job_id, output_folder = tempfile.gettempdir()):
                 start_time_rec = time.time()
                 try:
                     with contextlib.closing(db1.cursor()) as cursor:
-                        cursor.execute('update jobs set state="processing", progress = progress + 10 where job_id = '+str(job_id))
+                        cursor.execute("update jobs set state='processing', progress = progress + 10, last_update = now() where job_id = "+str(job_id))
                         db1.commit()
                 except Exception as e:
                     print(str(e))
@@ -297,21 +313,21 @@ def playlist_to_soundscape(job_id, output_folder = tempfile.gettempdir()):
             print('main: log: processing recordings results: ' + str(len(resultsParallel)))
             try:
                 with contextlib.closing(db.cursor()) as cursor:
-                    cursor.execute('update `jobs` set `state`="processing", \
-                        `progress` = `progress` + 1 where `job_id` = '+str(job_id))
+                    cursor.execute("update jobs set state='processing', \
+                        progress = progress + 1, last_update = now() where job_id = "+str(job_id))
                     db.commit()
             except Exception as e:
                 print(str(e))
                 try:
-                    print('Attempting to re-establish main MySQL connection')
+                    # mysql2pg: re-dial via the dialect-aware connect() (was a
+                    # hardcoded mysql.connector.connect); preserves the
+                    # reconnect-on-transient-drop behavior on both engines.
+                    print('Attempting to re-establish main database connection')
                     db.close()
-                    db = mysql.connector.connect(
-                        host=config['db_host'], user=config['db_user'],
-                        password=config['db_password'], database=config['db_name']
-                    )
+                    db = connect()
                     with contextlib.closing(db.cursor()) as cursor:
-                        cursor.execute('update `jobs` set `state`="processing", \
-                            `progress` = `progress` + 1 where `job_id` = '+str(job_id))
+                        cursor.execute("update jobs set state='processing', \
+                            progress = progress + 1, last_update = now() where job_id = "+str(job_id))
                         db.commit()
                 except Exception as e:
                     print('ERROR', str(e))
@@ -371,12 +387,17 @@ def playlist_to_soundscape(job_id, output_folder = tempfile.gettempdir()):
                 # the trigger will override our state='error' back to
                 # 'completed'. (completed=-1 is the authoritative error flag
                 # regardless, but keep state consistent for the frontend.)
+                # mysql2pg: PG has no jobs_BEFORE_UPDATE trigger, so the
+                # progress=0 reset is a harmless no-op there rather than a
+                # trigger-dodge; kept byte-identical (parity-first) plus the
+                # Defect-D last_update bump.
                 with contextlib.closing(db.cursor()) as cursor:
-                    cursor.execute('update `jobs` set `state`="error", '
-                        '`completed` = -1, `progress` = 0, '
-                        '`remarks` = \'Error: no usable '
-                        'recording data (all recordings missing or unreadable).\' '
-                        'where `job_id` = '+str(job_id))
+                    cursor.execute("update jobs set state='error', "
+                        "completed = -1, progress = 0, "
+                        "remarks = 'Error: no usable "
+                        "recording data (all recordings missing or unreadable).', "
+                        "last_update = now() "
+                        "where job_id = "+str(job_id))
                     db.commit()
                 shutil.rmtree(working_folder)
                 db.close()
@@ -392,11 +413,12 @@ def playlist_to_soundscape(job_id, output_folder = tempfile.gettempdir()):
                 statsMin = aggregation['range'][0]
                 statsMax = aggregation['range'][1]
 
+            # mysql2pg: backticks stripped (all-lowercase, portable both ways).
             query, query_data = ("""
-                INSERT INTO `soundscapes`( `name`, `project_id`, `user_id`,
-                `soundscape_aggregation_type_id`, `bin_size`, `uri`, `min_t`,
-                `max_t`, `min_f`, `max_f`, `min_value`, `max_value`,
-                `date_created`, `playlist_id`, `threshold` , `threshold_type` ,`frequency` ,`normalized`)
+                INSERT INTO soundscapes( name, project_id, user_id,
+                soundscape_aggregation_type_id, bin_size, uri, min_t,
+                max_t, min_f, max_f, min_value, max_value,
+                date_created, playlist_id, threshold , threshold_type ,frequency ,normalized)
                 VALUES (
                     %s, %s, %s, %s, %s, NULL, %s, %s, 0, %s, 0, %s, NOW(), %s,
                     %s, %s, %s, %s
@@ -411,12 +433,12 @@ def playlist_to_soundscape(job_id, output_folder = tempfile.gettempdir()):
             scpId = -1
             try:
                 with contextlib.closing(db.cursor()) as cursor:
-                    cursor.execute('update `jobs` set `state`="processing", \
-                        `progress` = `progress` + 1 where `job_id` = '+str(job_id))
+                    cursor.execute("update jobs set state='processing', \
+                        progress = progress + 1, last_update = now() where job_id = "+str(job_id))
                     db.commit()
-                    cursor.execute(query, query_data)
+                    # mysql2pg: cursor.lastrowid -> RETURNING soundscape_id on PG.
+                    scpId = insert_returning_id(cursor, query, query_data, 'soundscape_id')
                     db.commit()
-                    scpId = cursor.lastrowid
             except Exception as e:
                 print('WARN', 'progress increment', str(e))
 
@@ -429,8 +451,8 @@ def playlist_to_soundscape(job_id, output_folder = tempfile.gettempdir()):
             scp.write_image(working_folder + imgout, palette.get_palette())
             try:
                 with contextlib.closing(db.cursor()) as cursor:
-                    cursor.execute('update `jobs` set `state`="processing", \
-                        `progress` = `progress` + 1 where `job_id` = '+str(job_id))
+                    cursor.execute("update jobs set state='processing', \
+                        progress = progress + 1, last_update = now() where job_id = "+str(job_id))
                     db.commit()
             except Exception as e:
                 print(str(e))
@@ -454,15 +476,15 @@ def playlist_to_soundscape(job_id, output_folder = tempfile.gettempdir()):
                 bucket.upload_file(working_folder+imgout, imageUri, ExtraArgs={'ACL': 'public-read'})
                 try:
                     with contextlib.closing(db.cursor()) as cursor:
-                        cursor.execute('update `jobs` set `state`="processing", \
-                            `progress` = `progress` + 1 where `job_id` = '+str(job_id))
+                        cursor.execute("update jobs set state='processing', \
+                            progress = progress + 1, last_update = now() where job_id = "+str(job_id))
                         db.commit()
                 except Exception as e:
                     print('WARN', 'progress increment', str(e))
                 bucket.upload_file(working_folder+scidxout, indexUri, ExtraArgs={'ACL': 'public-read'})
                 with contextlib.closing(db.cursor()) as cursor:
-                    cursor.execute("update `soundscapes` set `uri` = '"+imageUri+"' \
-                        where  `soundscape_id` = "+str(soundscapeId))
+                    cursor.execute("update soundscapes set uri = '"+imageUri+"' \
+                        where  soundscape_id = "+str(soundscapeId))
                     db.commit()
 
                 bucket.upload_file(peaknFile+'.json', peaknumbersUri, ExtraArgs={'ACL': 'public-read'})
@@ -473,21 +495,26 @@ def playlist_to_soundscape(job_id, output_folder = tempfile.gettempdir()):
                 with contextlib.closing(db.cursor()) as cursor:
                     cursor.execute('delete from soundscapes where soundscape_id ='+str(scpId))
                     db.commit()
-                    cursor.execute('update `jobs` set `state`="error", \
-                        `completed` = -1,`remarks` = \'Error: Failed writing soundscape files.\' \
-                        where `job_id` = '+str(job_id))
+                    cursor.execute("update jobs set state='error', \
+                        completed = -1, remarks = 'Error: Failed writing soundscape files.', \
+                        last_update = now() where job_id = "+str(job_id))
                     db.commit()
         else:
             print('main: failed: no results from playlist id:'+playlist_id)
+            # mysql2pg NOTE (pre-existing behavior, preserved parity-first):
+            # this error path does NOT sys.exit, so it falls through to the
+            # trailing 'completed' update below, overriding error->completed.
+            # That is today's live MySQL behavior too (no trigger involved);
+            # flagged for the post-migration cleanup list, not silently fixed.
             with contextlib.closing(db.cursor()) as cursor:
-                cursor.execute('update `jobs` set `state`="error", \
-                    `completed` = -1,`remarks` = \'Error: No results found.\' \
-                    where `job_id` = '+str(job_id))
+                cursor.execute("update jobs set state='error', \
+                    completed = -1, remarks = 'Error: No results found.', \
+                    last_update = now() where job_id = "+str(job_id))
                 db.commit()
         try:
             with contextlib.closing(db.cursor()) as cursor:
-                cursor.execute('update `jobs` set `state`="completed", `completed`=1, \
-                    `progress` = `progress` + 1 where `job_id` = '+str(job_id))
+                cursor.execute("update jobs set state='completed', completed=1, \
+                    progress = progress + 1, last_update = now() where job_id = "+str(job_id))
                 db.commit()
         except Exception as e:
             print('WARN', 'progress completion', str(e))
@@ -503,9 +530,9 @@ def playlist_to_soundscape(job_id, output_folder = tempfile.gettempdir()):
         print(errmsg)
         with contextlib.closing(db.cursor()) as cursor:
             cursor.execute('\
-                UPDATE `jobs` \
-                SET `state`=%s, `completed`=%s, `remarks`=%s \
-                WHERE `job_id` = %s', [
+                UPDATE jobs \
+                SET state=%s, completed=%s, remarks=%s, last_update=now() \
+                WHERE job_id = %s', [
                 'error', -1, errmsg, job_id
             ])
             db.commit()

--- a/soundscapes/old/playlist_to_soundscape.py
+++ b/soundscapes/old/playlist_to_soundscape.py
@@ -16,16 +16,13 @@ from .a2audio.rec import Rec
 from .a2pyutils import palette
 from .indices import indices
 from .soundscape import soundscape
-from . import db as dbmod
 from .db import (
     connect,
-    year_expr,  # noqa: F401
     date_format_expr,
     datetime_str_expr,
     LEGACY_EXPR,
     cursor_column_names,
     insert_returning_id,
-    IS_PG,
 )
 
 config = {


### PR DESCRIPTION
Phase 5.5 jobs-plane flip — worker port **5/5 (soundscapes)**, the last of the W-lane. Env-gated (`ARBIMON_DB_DIALECT`, default `mysql` = byte-for-byte today's behavior); the postgres path activates only via env at the coordinated flip. Nothing changes for existing deploys.

## db.py
- dialect-aware `connect()` (psycopg2 | mysql.connector), `ARBIMON_DB_PORT` override.
- helpers mirroring the W4 pattern: `insert_returning_id` (lastrowid → RETURNING), `cursor_column_names` (column_names | description), `year_expr`, `date_format_expr` (DATE_FORMAT tokens → to_char/EXTRACT), `datetime_str_expr`, `LEGACY_EXPR` (IF(LEFT) → CASE). `get_automated_user`/`create_playlist`/`create_job` use RETURNING.

## playlist_to_soundscape.py (the live dispatcher path)
- backticks stripped; double-quoted `state` literals → single quotes (PG parses `"processing"` as an identifier — hard-error class); DATE_FORMAT / IF(LEFT) / year() → portable helpers.
- `cursor.lastrowid` → `insert_returning_id` for the soundscapes INSERT.
- **#28 / Defect-D:** every jobs write now bumps `last_update`. `jobs.last_update` is a plain `datetime` with **no** `ON UPDATE` clause → the old worker writes left it stale (a latent drift class even on today's MySQL). Final completion was already explicit; the 2026-06-09 blank-soundscape `progress=0` trigger-dodge is kept byte-identical (harmless no-op on PG, which has no `jobs_BEFORE_UPDATE` trigger).
- fixed a latent bug on the main-connection reconnect `except` path: it re-dialed via a bare `mysql.connector.connect(config['db_host']…)` but this module never imported `mysql` and its local `config` holds only S3 keys → NameError/KeyError on that path. Now re-dials via `connect()` on both engines.

## Preserved parity-first (flagged, not silently fixed)
The 'No results found' path does not `sys.exit`, so it falls through to the trailing completion update (overriding error→completed). That is today's live MySQL behavior too (no trigger involved) — flagged for the post-migration cleanup list.

## Validation — RO smoke on both live engines
- **PG:** all 3 read shapes plan cleanly (to_char/CASE/EXTRACT resolve via index scans), all 9 jobs UPDATEs execute, soundscapes INSERT…RETURNING + uri UPDATE + DELETE — all rolled back. soundscapes parity **11779 = 11779**.
- **MySQL:** reads + all ported UPDATEs execute clean.
- `create_job`/`create_playlist`/`get_automated_user` RETURNING are structurally valid; the interim jobs/playlists/users **sequence-lag** is the documented plan §3 flip-day `setval` item, and those internal-batch paths have **no rfcx-local caller** (legacy creates soundscape jobs in MariaDB).

`psycopg2-binary` added to requirements.txt (installed by both the repo build and the production `_patches/arbimon-soundscapes.Dockerfile`; inactive unless dialect=postgres).

Refs OPEN-ITEMS #40. Docs (runbook + OVERVIEW) land in a companion rfcx-local PR.