### PR TITLE
fix(soundscape): derive in-pod concurrency from recording size (OOM on ultrasonic audio)

### DIFF
--- a/soundscapes/old/playlist_to_soundscape.py
+++ b/soundscapes/old/playlist_to_soundscape.py
@@ -135,7 +135,12 @@ def playlist_to_soundscape(job_id, output_folder = tempfile.gettempdir()):
         # datetime_str_expr (to_char on PG, byte-identical text on MySQL);
         # IF(LEFT(...)) -> LEGACY_EXPR CASE (identical both engines);
         # backticks stripped (all-lowercase identifiers, portable both ways).
-        q = ("SELECT r.recording_id, uri, " + datetime_str_expr('datetime') + " as date, " + LEGACY_EXPR + " legacy \
+        # rfcx-local 2026-07-25: also project sample_rate/duration/samples so
+        # in-pod concurrency can be DERIVED from signal size (see the adaptive
+        # concurrency block below). These columns already exist on `recordings`
+        # and are portable across both engines.
+        q = ("SELECT r.recording_id, uri, " + datetime_str_expr('datetime') + " as date, " + LEGACY_EXPR + " legacy, \
+            r.sample_rate, r.duration, r.samples \
             FROM playlist_recordings pr \
             JOIN recordings r ON pr.recording_id = r.recording_id \
             WHERE playlist_id = " + str(playlist_id))
@@ -153,7 +158,10 @@ def playlist_to_soundscape(job_id, output_folder = tempfile.gettempdir()):
                     "uri": row[1],
                     "id": row[0],
                     "date": row[2],
-                    "legacy": row[3]
+                    "legacy": row[3],
+                    "sample_rate": row[4],
+                    "duration": row[5],
+                    "samples": row[6]
                 })
             print('main: log: playlist recordings list retrieved', totalRecs)
         try:
@@ -182,6 +190,69 @@ def playlist_to_soundscape(job_id, output_folder = tempfile.gettempdir()):
         peaknumbers  = indices.Indices(aggregation)
         hIndex = indices.Indices(aggregation)
         aciIndex = indices.Indices(aggregation)
+
+        # ---- adaptive in-pod concurrency (rfcx-local 2026-07-25) ----
+        # WHY: fpeaks.R/aci.R readWave() the ENTIRE signal, promote it to a
+        # double vector and retain both copies, so worker memory is driven by
+        # SAMPLES PER RECORDING x CONCURRENCY -- not by recording count and not
+        # by bin_size. Measured in the production image (cgroup accounting, the
+        # same counter the OOM killer enforces):
+        #   384kHz/59s (22,656,000 samples): c=1 1.48GB | c=2 2.84GB | c=3 4.22GB
+        #    48kHz/60s ( 2,880,000 samples): c=1 0.08GB | c=3 0.67GB | c=6 1.08GB
+        #   => ~64.9 bytes/sample/process, linear across both classes.
+        # jobs.ncpu (typically 3) was applied UNCONDITIONALLY, so a playlist of
+        # ultrasonic AudioMoth audio (384kHz) exceeded a 3Gi container limit and
+        # was OOMKilled -- deterministically, at any playlist size.
+        #
+        # Rather than raising the memory limit (masks the defect) or blanket
+        # serializing (needlessly slows the ~99% of recordings that are small,
+        # on jobs that already run for hours), derive a concurrency that keeps
+        # the WORST recording in this playlist inside the budget.
+        #
+        # SCIENTIFICALLY INERT: this only changes how many recordings are
+        # processed concurrently. processRec() has no cross-recording state and
+        # the aggregation/reduce is untouched, so results are unchanged.
+        def _worst_samples(recs_list):
+            worst = 0
+            for r in recs_list:
+                s = r.get("samples")
+                if not s:
+                    sr, dur = r.get("sample_rate"), r.get("duration")
+                    try:
+                        s = int(sr) * int(dur) if (sr and dur) else None
+                    except (TypeError, ValueError):
+                        s = None
+                if not s:
+                    return None          # unknown -> caller assumes worst case
+                try:
+                    worst = max(worst, int(s))
+                except (TypeError, ValueError):
+                    return None
+            return worst
+
+        _bytes_per_sample = float(os.getenv('SOUNDSCAPE_BYTES_PER_SAMPLE', '64.9'))
+        _proc_overhead_gb = float(os.getenv('SOUNDSCAPE_PROC_OVERHEAD_GB', '0.06'))
+        _fixed_gb = float(os.getenv('SOUNDSCAPE_FIXED_GB', '0.25'))
+        _safety = float(os.getenv('SOUNDSCAPE_MEM_SAFETY', '0.75'))
+        _limit_gb = float(os.getenv('SOUNDSCAPE_MEM_LIMIT_GB', '3.0'))
+
+        _ws = _worst_samples(recsToProcess)
+        if _ws is None:
+            # Missing size metadata: fail SAFE (a wrong guess here is an OOM).
+            print('main: log: concurrency 1 (recording size unknown -> worst case)')
+            num_cores = 1
+        else:
+            _per_proc = _ws * _bytes_per_sample / (1024.0 ** 3) + _proc_overhead_gb
+            _usable = _limit_gb * _safety - _fixed_gb
+            _safe = max(1, int(_usable // _per_proc)) if _per_proc > 0 else 1
+            if _safe < num_cores:
+                print('main: log: reducing concurrency %d -> %d (worst recording '
+                      '%d samples, ~%.2f GB/process, budget %.2f GB)'
+                      % (num_cores, _safe, _ws, _per_proc, _usable))
+                num_cores = _safe
+            else:
+                print('main: log: concurrency %d retained (worst recording %d '
+                      'samples, ~%.2f GB/process)' % (num_cores, _ws, _per_proc))
 
         print("main: log: start parallel processing")
 


### PR DESCRIPTION
## Problem

Soundscape workers are **OOMKilled on high-sample-rate (ultrasonic) playlists**. It is deterministic and independent of playlist size — the affected job died at 11/705 recordings, and a re-run died again at the same point.

Real example: an AudioMoth playlist recorded at **384 kHz** (bat/ultrasonic monitoring, `384000 GAIN 2`).

## Root cause

`fpeaks.R` / `aci.R` `readWave()` the **entire** signal, then `data <- data/channel.max` promotes it to an 8-byte double vector and assigns it back (`archivo@left <- data`), retaining **both** copies, before `meanspec()` runs over the whole signal.

So worker memory is driven by **samples per recording × concurrency** — *not* by the number of recordings, and *not* by `bin_size`.

`jobs.ncpu` (typically 3) was applied **unconditionally** through `Parallel(n_jobs=num_cores)`, and each forked worker spawns its own `Rscript`.

## Measurements

Taken in the production image using cgroup accounting — the same counter the OOM killer enforces — on one real 384 kHz recording and one ordinary 48 kHz recording:

| audio | samples | c=1 | c=2 | c=3 | c=6 |
|---|---|---|---|---|---|
| 384 kHz / 59 s | 22,656,000 | 1.48 GB | 2.84 GB | **4.22 GB** | – |
| 48 kHz / 60 s | 2,880,000 | 0.08 GB | – | 0.67 GB | 1.08 GB |

→ **~64.9 bytes/sample/process**, linear and consistent across both classes.

Against a 3 GiB container limit, `c=3` on the 384 kHz playlist = **4.22 GB → killed**.

Worth noting: **peak RSS is flat across `bin_size`** (1.38 / 1.34 / 1.38 GB at 43 / 172 / 344) even though peak *counts* differ ~10× (2163 / 499 / 220). That rules out `bin_size` as the driver.

## Fix

Derive concurrency from the worst recording in the playlist:

```
per_proc = samples * 64.9 / 2^30 + 0.06
usable   = (limit * 0.75) - 0.25
cores    = clamp(1, ncpu, floor(usable / per_proc))
```

Validated against the real production distribution of soundscape playlists:

| sample_rate | max samples | derived concurrency | peak |
|---|---|---|---|
| 24 kHz | 1,440,000 | 3 (full `ncpu`) | 0.69 GB |
| 48 kHz | 5,639,690 | 3 (full `ncpu`) | 0.95 GB |
| 192 kHz | 16,752,632 | 1 | 1.32 GB |
| 384 kHz | 22,656,000 | 1 | 1.68 GB |

Every class fits, and the common 24/48 kHz classes (**~99% of recordings**) keep their **full `ncpu` concurrency** — so the ~14,700 normal jobs are not slowed.

This also covers a **second latent OOM that has not been hit yet**: 192 kHz / 16,752,632 samples × 3 ≈ **3.47 GB**, likewise over the limit.

### Alternatives rejected

- **Raising the memory limit** — masks a process defect and scales badly as ultrasonic deployments grow.
- **Blanket serialization (`n_jobs=1`)** — would fix the OOM but needlessly slow ~99% of recordings, on jobs that already run up to 643 minutes.

## Safety and correctness

- **Scientifically inert.** Only the *degree* of concurrency changes. `processRec()` has no cross-recording state and the aggregation/reduce path is untouched, so outputs are unchanged.
- **Fails safe.** If size metadata is missing or unparseable, it falls back to concurrency 1 rather than risk an OOM.
- **Tunable.** `SOUNDSCAPE_MEM_LIMIT_GB`, `SOUNDSCAPE_BYTES_PER_SAMPLE`, `SOUNDSCAPE_MEM_SAFETY`, `SOUNDSCAPE_PROC_OVERHEAD_GB`, `SOUNDSCAPE_FIXED_GB`.

## Verification

- Policy logic exercised against the **actual patched file**: 10/10 cases pass, including mixed playlists (one large recording among 99 small — correctly drops to 1), `samples` NULL → `sample_rate × duration` fallback, garbage metadata → safe, and the invariant that predicted peak < limit in every case.
- The added `sample_rate, duration, samples` projection was **executed on both live engines** (PostgreSQL and MariaDB) and returns identical values; those columns are **non-NULL for all 10,527 recordings** across the sampled soundscape playlists.
- `python3 -m py_compile` clean.

## Note on scope

This is the minimal, low-risk fix for the OOM class. A follow-up design exists to shard soundscape analysis across pods via the analysis MQ lanes (as Pattern Matching and AED already do), which would also address the multi-hour runtimes and make the job type reaper-resumable. That is deliberately **not** in this PR.